### PR TITLE
Add support to MAV_CMD_REQUEST_MESSAGE

### DIFF
--- a/src/mavsdk/plugins/camera_server/camera_server_impl.h
+++ b/src/mavsdk/plugins/camera_server/camera_server_impl.h
@@ -152,6 +152,8 @@ private:
     void stop_image_capture_interval();
 
     std::optional<mavlink_command_ack_t>
+    process_camera_request(const MavlinkCommandReceiver::CommandLong& command);
+    std::optional<mavlink_command_ack_t>
     process_camera_information_request(const MavlinkCommandReceiver::CommandLong& command);
     std::optional<mavlink_command_ack_t>
     process_camera_settings_request(const MavlinkCommandReceiver::CommandLong& command);
@@ -189,6 +191,17 @@ private:
     process_video_stream_information_request(const MavlinkCommandReceiver::CommandLong& command);
     std::optional<mavlink_command_ack_t>
     process_video_stream_status_request(const MavlinkCommandReceiver::CommandLong& command);
+
+    std::optional<mavlink_command_ack_t>
+    process_camera_information(const MavlinkCommandReceiver::CommandLong& command);
+    std::optional<mavlink_command_ack_t>
+    process_camera_settings(const MavlinkCommandReceiver::CommandLong& command);
+    std::optional<mavlink_command_ack_t>
+    process_storage_information(const MavlinkCommandReceiver::CommandLong& command, uint8_t storage_id);
+    std::optional<mavlink_command_ack_t>
+    process_video_stream_information(const MavlinkCommandReceiver::CommandLong& command, uint8_t stream_id);
+    std::optional<mavlink_command_ack_t>
+    process_video_stream_status(const MavlinkCommandReceiver::CommandLong& command, uint8_t stream_id);
 
     void send_capture_status();
 


### PR DESCRIPTION
In resposne to following commit in QGroundControl: Switch to use standard Vehicle methods
https://github.com/mavlink/qgroundcontrol/commit/7e581a14ffa1b58d6876b3af2168b2e3b43a79fb